### PR TITLE
Implementation updates

### DIFF
--- a/src/database/heap_page_id.cpp
+++ b/src/database/heap_page_id.cpp
@@ -1,8 +1,15 @@
 #include "heap_page_id.h"
+#include <stdexcept>
 
 namespace buzzdb {
 HeapPageId::HeapPageId(int table_id, int page_number)
     : table_id(table_id), page_number(page_number) {
+  if (table_id < 0) {
+    throw std::invalid_argument("Table id cannot be negative.");
+  }
+  if (page_number < 0) {
+    throw std::invalid_argument("Page number cannot be negative.");
+  }
 }
 
 HeapPageId::HeapPageId(const HeapPageId & original)

--- a/src/database/record_id.cpp
+++ b/src/database/record_id.cpp
@@ -1,9 +1,12 @@
 #include "record_id.h"
-#include "heap_page_id.h"
+#include <stdexcept>
 
 namespace buzzdb {
 RecordId::RecordId(PageId & pid, int tuple_number)
     : pid(pid), tuple_number(tuple_number) {
+  if (tuple_number < 0) {
+    throw std::invalid_argument("Tuple number cannot be negative.");
+  }
 }
 
 int RecordId::get_tuple_number() const {

--- a/src/database/tuple.cpp
+++ b/src/database/tuple.cpp
@@ -41,12 +41,12 @@ const std::vector<Field *> & Tuple::get_fields() const {
   return fields;
 }
 
-Field * Tuple::get_field(int i) const {
-  if (i < 0) {
-    throw std::domain_error("Index cannot be negative.");
+Field * Tuple::get_field(int index) const {
+  if (index < 0) {
+    throw std::invalid_argument("Index cannot be negative.");
   }
 
-  unsigned int unsigned_index = i;
+  unsigned int unsigned_index = index;
   if (unsigned_index >= fields.size()) {
     throw std::out_of_range("Index is out of range.");
   }
@@ -57,24 +57,25 @@ const TupleDesc & Tuple::get_tuple_desc() const {
   return td;
 }
 
-RecordId * Tuple::get_record_id() const {
+const RecordId * Tuple::get_record_id() const {
   return rid;
 }
 
-void Tuple::set_field(int i, Field * f) {
-  if (i < 0) {
-    throw std::domain_error("Index cannot be negative.");
+void Tuple::set_field(int index, Field * f) {
+  if (index < 0) {
+    throw std::invalid_argument("Index cannot be negative.");
   }
 
-  unsigned int unsigned_index = i;
+  unsigned int unsigned_index = index;
   if (unsigned_index >= fields.size()) {
     throw std::out_of_range("Index is out of range.");
   }
+
   // type check is yet to be implemented.
   if (false) {
     throw std::invalid_argument("Type of *f is incorrect.");
   };
-  fields[i] = f;
+  fields.at(unsigned_index) = f;
 }
 
 void Tuple::set_record_id(RecordId * rid) {

--- a/src/database/tuple_desc.cpp
+++ b/src/database/tuple_desc.cpp
@@ -17,7 +17,7 @@ TupleDesc::TupleDesc(std::vector<Field::Type> type_vector,
                      std::vector<std::string> name_vector) {
   if (type_vector.size() != name_vector.size()) {
     throw std::invalid_argument(
-        "Pre-condition violation: Type vector and name vector differ in size");
+        "Type vector and name vector cannot have different lengths.");
   }
   types = type_vector;
   names = name_vector; 
@@ -41,24 +41,24 @@ int TupleDesc::get_size() const {
   return size;
 }
 
-const Field::Type & TupleDesc::get_field_type(int i) const {
-  if (i < 0) {
-    throw std::domain_error("Index cannot be negative.");
+const Field::Type & TupleDesc::get_field_type(int index) const {
+  if (index < 0) {
+    throw std::invalid_argument("Index cannot be negative.");
   }
 
-  unsigned int unsigned_index = i;
+  unsigned int unsigned_index = index;
   if (unsigned_index >= types.size()) {
     throw std::out_of_range("Index is out of range.");
   }
   return types[unsigned_index];
 }
 
-const std::string & TupleDesc::get_field_name(int i) const {
-  if (i < 0) {
-    throw std::domain_error("Index cannot be negative.");
+const std::string & TupleDesc::get_field_name(int index) const {
+  if (index < 0) {
+    throw std::invalid_argument("Index cannot be negative.");
   }
 
-  unsigned int unsigned_index = i;
+  unsigned int unsigned_index = index;
   if (unsigned_index >= names.size()) {
     throw std::out_of_range("Index is out of range.");
   }

--- a/src/include/tuple.h
+++ b/src/include/tuple.h
@@ -39,14 +39,14 @@ class Tuple {
   const std::vector<Field *> & get_fields() const;
 
   /**
-   * Returns the value of the i-th field.
+   * Returns the value of the i-th field, where i is given by index.
    * If the i-th field has not been set, returns a nullptr.
    * 
    * Throws:
-   * - std::domain_error: If i < 0. 
-   * - std::out_of_range: If i >= number of fields. 
+   * - std::invalid_argument: If index < 0. 
+   * - std::out_of_range: If index >= number of fields. 
    */
-  Field * get_field(int i) const;
+  Field * get_field(int index) const;
 
   /**
    * Returns the TupleDesc.
@@ -57,22 +57,23 @@ class Tuple {
   /**
    * Returns the disk location representation of the Tuple.
    */
-  RecordId * get_record_id() const;
+  const RecordId * get_record_id() const;
 
   /**
-   * Changes the value of the i-th field of the Tuple to f.
+   * Changes the value of the i-th field of the Tuple to f, where i is given
+   * by index.
    * 
    * Pre-condition:
    * - f should not be pointing to a Field object already pointed to by
-   *   another Tuple. Failure to ensure this constraint will lead to
+   *   another Tuple. Failure to ensure this constraint will result in
    *   undefined behaviour.
    * Throws:
-   * - std::domain_error: If i < 0. 
-   * - std::out_of_range: If i >= number of fields. 
+   * - std::invalid_argument: If index < 0. 
+   * - std::out_of_range: If index >= number of fields. 
    * - std::invalid_argument: If f is of incorrect Type, as specified by the
    *   TupleDesc. 
    */
-  void set_field(int i, Field * f);
+  void set_field(int index, Field * f);
   
   /**
    * Sets the disk location information for the Tuple.

--- a/src/include/tuple_desc.h
+++ b/src/include/tuple_desc.h
@@ -61,22 +61,22 @@ class TupleDesc {
   int get_size() const;
 
   /**
-   * Returns the type of the i-th field.
+   * Returns the type of the i-th field, where i is given by index.
    * 
    * Throws:
-   * - std::domain_error: If i < 0. 
-   * - std::out_of_range: If i >= number of fields. 
+   * - std::invalid_argument: If index < 0. 
+   * - std::out_of_range: If index >= number of fields. 
    */
-  const Field::Type & get_field_type(int i) const;
+  const Field::Type & get_field_type(int index) const;
 
   /**
-   * Returns the name of the i-th field.
+   * Returns the name of the i-th field, where i is given by index.
    * 
    * Throws:
-   * - std::domain_error: If i < 0. 
-   * - std::out_of_range: If i >= number of fields. 
+   * - std::invalid_argument: If index < 0. 
+   * - std::out_of_range: If index >= number of fields. 
    */
-  const std::string & get_field_name(int i) const;
+  const std::string & get_field_name(int index) const;
 
   /**
    * Returns the index of the first field with a given name.

--- a/test/heap_page_id_unit_test.cpp
+++ b/test/heap_page_id_unit_test.cpp
@@ -1,48 +1,67 @@
 #include <gtest/gtest.h>
+#include <stdexcept>
 #include "heap_page_id.h"
 
 namespace buzzdb {
-/**
- * Unit test suite: HeapPageId
- */
-TEST(GetterTests, GetTableIdWorksCorrectly) {
-  HeapPageId heap_page_id(1, 1);
+class HeapPageIdUnitTest : public ::testing::Test {
+ protected:
+  HeapPageIdUnitTest() : heap_page_id(1, 1) {
+  }
 
+  HeapPageId heap_page_id;
+};
+
+class GetterTests : public HeapPageIdUnitTest {
+ protected:
+  GetterTests() {
+  }
+};
+
+class CopyConstructorTest : public HeapPageIdUnitTest {
+ protected:
+  CopyConstructorTest() {
+  }
+};
+
+class OverloadedOperatorTests : public HeapPageIdUnitTest {
+ protected:
+  OverloadedOperatorTests()
+      : heap_page_id_same(1, 1),
+        heap_page_id_different_table_id(10, 1),
+        heap_page_id_different_page_number(1, 27),
+        heap_page_id_different(10, 27) {
+  }
+
+  HeapPageId heap_page_id_same;
+  HeapPageId heap_page_id_different_table_id;
+  HeapPageId heap_page_id_different_page_number;
+  HeapPageId heap_page_id_different;
+};
+
+/**
+ * HeapPageId: Unit Test
+ */
+TEST_F(GetterTests, GetTableIdWorksCorrectly) {
   EXPECT_EQ(1, heap_page_id.get_table_id());
 }
 
-TEST(GetterTests, GetPageNumberWorksCorrectly) {
-  HeapPageId heap_page_id(1, 1);
-
+TEST_F(GetterTests, GetPageNumberWorksCorrectly) {
   EXPECT_EQ(1, heap_page_id.get_page_number());
 }
 
-TEST(ConstructorTests, ConstructorWorksCorrectly) {
-  HeapPageId heap_page_id_new(22, 0);
+TEST(ConstructorTest, ConstructorWorksCorrectly) {
+  HeapPageId heap_page_id(1, 1);
 
-  EXPECT_EQ(22, heap_page_id_new.get_table_id());
-  EXPECT_EQ(0, heap_page_id_new.get_page_number());
+  EXPECT_EQ(1, heap_page_id.get_table_id());
+  EXPECT_EQ(1, heap_page_id.get_page_number());
+
+  // invalid table id
+  EXPECT_THROW(HeapPageId invalid_heap_page_id(-1, 1), std::invalid_argument);
+  // invalid page number
+  EXPECT_THROW(HeapPageId invalid_heap_page_id(1, -1), std::invalid_argument);
 }
 
-TEST(ConstructorTests, CopyConstructorWorksCorrectly) {
-  HeapPageId heap_page_id(1, 1);
-  HeapPageId heap_page_id_copy = heap_page_id;
-
-  EXPECT_EQ(heap_page_id.get_table_id(), heap_page_id_copy.get_table_id());
-  EXPECT_EQ(heap_page_id.get_page_number(), heap_page_id_copy.get_page_number());
-
-  // check that the two objects are distinct
-  EXPECT_NE(&heap_page_id, &heap_page_id_copy);
-}
-
-TEST(OperatorOverloadTests, EqualityOperatorWorksCorrectly) {
-  HeapPageId heap_page_id(1, 1);
-  HeapPageId heap_page_id_same(1, 1);
-  HeapPageId heap_page_id_different_table_id(10, 1);
-  HeapPageId heap_page_id_different_page_number(1, 27);
-  HeapPageId heap_page_id_different(10, 27);
-  HeapPageId heap_page_id_copy = heap_page_id;
-
+TEST_F(OverloadedOperatorTests, EqualityOperatorWorksCorrectly) {
   // check comparison with self
   EXPECT_TRUE(heap_page_id == heap_page_id);
 
@@ -52,27 +71,17 @@ TEST(OperatorOverloadTests, EqualityOperatorWorksCorrectly) {
   // check commutativity of operator
   EXPECT_TRUE(heap_page_id_same == heap_page_id);
 
-  // check comparison with copy of self 
-  EXPECT_TRUE(heap_page_id == heap_page_id_copy);
-
-  // check comparison with different table id
+  // check comparison with different table id only
   EXPECT_FALSE(heap_page_id == heap_page_id_different_table_id);
 
-  // check comparison with different page number
+  // check comparison with different page number only
   EXPECT_FALSE(heap_page_id == heap_page_id_different_page_number);
 
   // check comparison with different values
   EXPECT_FALSE(heap_page_id == heap_page_id_different);
 }
 
-TEST(OperatorOverloadTest, InequalityOperatorWorksCorrectly) {
-  HeapPageId heap_page_id(1, 1);
-  HeapPageId heap_page_id_same(1, 1);
-  HeapPageId heap_page_id_different_table_id(10, 1);
-  HeapPageId heap_page_id_different_page_number(1, 27);
-  HeapPageId heap_page_id_different(10, 27);
-  HeapPageId heap_page_id_copy = heap_page_id;
-
+TEST_F(OverloadedOperatorTests, InequalityOperatorWorksCorrectly) {
   // check comparison with self
   EXPECT_FALSE(heap_page_id != heap_page_id);
 
@@ -82,17 +91,25 @@ TEST(OperatorOverloadTest, InequalityOperatorWorksCorrectly) {
   // check commutativity of operator
   EXPECT_FALSE(heap_page_id_same != heap_page_id);
 
-  // check comparison with copy of self 
-  EXPECT_FALSE(heap_page_id != heap_page_id_copy);
-
-  // check comparison with different table id
+  // check comparison with different table id only
   EXPECT_TRUE(heap_page_id != heap_page_id_different_table_id);
 
-  // check comparison with different page number
+  // check comparison with different page number only
   EXPECT_TRUE(heap_page_id != heap_page_id_different_page_number);
 
   // check comparison with different values
   EXPECT_TRUE(heap_page_id != heap_page_id_different);
+}
+
+TEST_F(CopyConstructorTest, CopyConstructorWorksCorrectly) {
+  HeapPageId heap_page_id_copy = heap_page_id;
+
+  // check that the two objects are equal
+  // Implementation note: using EXPECT_EQ throws a compile error, not sure why.
+  EXPECT_TRUE(heap_page_id == heap_page_id_copy);
+
+  // check that the two objects are distinct
+  EXPECT_NE(&heap_page_id, &heap_page_id_copy);
 }
 }
 
@@ -101,6 +118,5 @@ TEST(OperatorOverloadTest, InequalityOperatorWorksCorrectly) {
  */
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    int result = RUN_ALL_TESTS();
-    return result;
+    return RUN_ALL_TESTS();
 }

--- a/test/record_id_unit_test.cpp
+++ b/test/record_id_unit_test.cpp
@@ -3,47 +3,78 @@
 #include "heap_page_id.h"
 
 namespace buzzdb {
-/**
- * Unit test suite: RecordId
- */
-TEST(GetterTests, GetPageIdWorksCorrectly) {
-  RecordId record_id(HeapPageId(1, 1), 1);
+class RecordIdUnitTest : public ::testing::Test {
+ protected:
+  RecordIdUnitTest()
+    : sample_heap_page_id(1, 1), record_id(sample_heap_page_id, 1) {
+  }
 
+  HeapPageId sample_heap_page_id;
+  RecordId record_id;
+};
+
+class GetterTests : public RecordIdUnitTest {
+ protected:
+  GetterTests() {
+  }
+};
+
+class ConstructorTest : public RecordIdUnitTest {
+ protected:
+  ConstructorTest() {
+  }
+};
+
+class OverloadedOperatorTests : public RecordIdUnitTest {
+ protected:
+  OverloadedOperatorTests()
+      : different_heap_page_id(2, 2),
+        record_id(sample_heap_page_id, 1),
+        record_id_same(sample_heap_page_id, 1),
+        record_id_different_page_id(different_heap_page_id, 1),
+        record_id_different_tuple_number(sample_heap_page_id, 2),
+        record_id_different(different_heap_page_id, 2) {
+  }
+
+  HeapPageId different_heap_page_id;
+  RecordId record_id;
+  RecordId record_id_same;
+  RecordId record_id_different_page_id;
+  RecordId record_id_different_tuple_number;
+  RecordId record_id_different;
+};
+
+class CopyConstructorTest : public RecordIdUnitTest {
+ protected:
+  CopyConstructorTest() {
+  }
+};
+
+/**
+ * RecordId: Unit Test
+ */
+TEST_F(GetterTests, GetPageIdWorksCorrectly) {
   EXPECT_EQ(HeapPageId(1, 1), record_id.get_page_id());
 }
 
-TEST(GetterTests, GetTupleNumberWorksCorrectly) {
-  RecordId record_id(HeapPageId(1, 1), 1);
-
+TEST_F(GetterTests, GetTupleNumberWorksCorrectly) {
   EXPECT_EQ(1, record_id.get_tuple_number());
 }
 
-TEST(ConstructorTests, ConstructorWorksCorrectly) {
-  RecordId record_id_new(HeapPageId(1, 2), 3);
+TEST_F(ConstructorTest, ConstructorWorksCorrectly) {
+  EXPECT_EQ(HeapPageId(1, 1), record_id.get_page_id());
+  EXPECT_EQ(1, record_id.get_tuple_number());
 
-  EXPECT_EQ(HeapPageId(1, 2), record_id_new.get_page_id());
-  EXPECT_EQ(3, record_id_new.get_tuple_number());
+  // invalid PageId
+  HeapPageId invalid_heap_page_id(-1, -1);
+  EXPECT_THROW(RecordId invalid_record_id(invalid_heap_page_id, 1),
+               std::invalid_argument);
+  // invalid tuple number
+  EXPECT_THROW(RecordId invalid_record_id(sample_heap_page_id, -1),
+               std::invalid_argument);
 }
 
-TEST(ConstructorTests, CopyConstructorWorksCorrectly) {
-  RecordId record_id(HeapPageId(1, 1), 1);
-  RecordId record_id_copy = record_id;
-
-  EXPECT_EQ(record_id.get_page_id(), record_id_copy.get_page_id());
-  EXPECT_EQ(record_id.get_tuple_number(), record_id_copy.get_tuple_number());
-
-  // check that the two objects are distinct
-  EXPECT_NE(&record_id, &record_id_copy);
-}
-
-TEST(OperatorOverloadTests, EqualityOperatorWorksCorrectly) {
-  RecordId record_id(HeapPageId(1, 1), 1);
-  RecordId record_id_same(HeapPageId(1, 1), 1);
-  RecordId record_id_different_page_id(HeapPageId(2, 2), 1);
-  RecordId record_id_different_tuple_number(HeapPageId(1, 1), 2);
-  RecordId record_id_different(HeapPageId(2, 2), 2);
-  RecordId record_id_copy = record_id;
-
+TEST_F(OverloadedOperatorTests, EqualityOperatorWorksCorrectly) {
   // check comparison with self
   EXPECT_TRUE(record_id == record_id);
 
@@ -53,27 +84,17 @@ TEST(OperatorOverloadTests, EqualityOperatorWorksCorrectly) {
   // check commutativity of operator
   EXPECT_TRUE(record_id_same == record_id);
 
-  // check comparison with copy of self 
-  EXPECT_TRUE(record_id == record_id_copy);
+  // check comparison with different page id
+  EXPECT_FALSE(record_id == record_id_different_page_id);
 
-  // check comparison with different table id
-  EXPECT_FALSE(record_id == record_id_different_table_id);
-
-  // check comparison with different page number
-  EXPECT_FALSE(record_id == record_id_different_page_number);
+  // check comparison with different tuple number
+  EXPECT_FALSE(record_id == record_id_different_tuple_number);
 
   // check comparison with different values
   EXPECT_FALSE(record_id == record_id_different);
 }
 
-TEST(OperatorOverloadTest, InequalityOperatorWorksCorrectly) {
-  RecordId record_id(HeapPageId(1, 1), 1);
-  RecordId record_id_same(HeapPageId(1, 1), 1);
-  RecordId record_id_different_page_id(HeapPageId(2, 2), 1);
-  RecordId record_id_different_tuple_number(HeapPageId(1, 1), 2);
-  RecordId record_id_different(HeapPageId(2, 2), 2);
-  RecordId record_id_copy = record_id;
-
+TEST_F(OverloadedOperatorTests, InequalityOperatorWorksCorrectly) {
   // check comparison with self
   EXPECT_FALSE(record_id != record_id);
 
@@ -83,17 +104,25 @@ TEST(OperatorOverloadTest, InequalityOperatorWorksCorrectly) {
   // check commutativity of operator
   EXPECT_FALSE(record_id_same != record_id);
 
-  // check comparison with copy of self 
-  EXPECT_FALSE(record_id != record_id_copy);
+  // check comparison with different page id
+  EXPECT_TRUE(record_id != record_id_different_page_id);
 
-  // check comparison with different table id
-  EXPECT_TRUE(record_id != record_id_different_table_id);
-
-  // check comparison with different page number
-  EXPECT_TRUE(record_id != record_id_different_page_number);
+  // check comparison with different tuple number
+  EXPECT_TRUE(record_id != record_id_different_tuple_number);
 
   // check comparison with different values
   EXPECT_TRUE(record_id != record_id_different);
+}
+
+TEST_F(CopyConstructorTest, CopyConstructorWorksCorrectly) {
+  RecordId record_id_copy = record_id;
+
+  // check that the two objects are equal
+  // Implementation note: using EXPECT_EQ throws a compile error, not sure why.
+  EXPECT_TRUE(record_id == record_id_copy);
+
+  // check that the two objects are distinct
+  EXPECT_NE(&record_id, &record_id_copy);
 }
 }
 


### PR DESCRIPTION
Partially addresses #18, #19.

The following classes were updated:
- HeapPageId, RecordId, Tuple, TupleDesc: Missing throw statements added
- HeapPageIdUnitTest, RecordIdUnitTest: Implementations restructured to use GTest fixtures, new tests added

---

Currently, there are still some minor compiler (GCC specific) issues with certain test cases in RecordIdUnitTest. Hence, it remains disabled for now.