### PR TITLE
Reimplement HeapPage class

### DIFF
--- a/src/database/buffer_pool.cpp
+++ b/src/database/buffer_pool.cpp
@@ -122,7 +122,7 @@ void BufferPool::InsertTuple(TransactionId * tid, int table_id, Tuple * t) {
   std::vector<Page*> page_vector =
       catalog->get_db_file(table_id)->AddTuple(*tid, *t);
   for (Page * page: page_vector) {
-    page->MarkDirty(true, *tid);
+    page->MarkDirty(true, tid);
   }
 }
 
@@ -132,7 +132,7 @@ void BufferPool::DeleteTuple(TransactionId * tid, Tuple * t) {
 
   DbFile * db_file = catalog->get_db_file(table_id);
 
-  db_file->DeleteTuple(*tid, *t)->MarkDirty(true, *tid);
+  db_file->DeleteTuple(*tid, *t)->MarkDirty(true, tid);
 }
 
 void BufferPool::FlushAllPages() {

--- a/src/database/buffer_pool.cpp
+++ b/src/database/buffer_pool.cpp
@@ -11,10 +11,6 @@ BufferPool::~BufferPool() {
   buffer_pool = nullptr;
 }
 
-int BufferPool::get_page_size() {
-  return PAGE_SIZE;
-}
-
 Page * BufferPool::get_page(TransactionId * tid, 
                             PageId * pid, 
                             Permissions * perm) {

--- a/src/database/heap_file.cpp
+++ b/src/database/heap_file.cpp
@@ -25,7 +25,7 @@ TupleDesc HeapFile::get_tuple_desc() const {
 }
 
 int HeapFile::get_num_pages() {
-  return (int) ceil(ftell(file) / BufferPool::get_page_size());
+  return (int) ceil(ftell(file) / BufferPool::PAGE_SIZE);
 }
 
 Page * HeapFile::ReadPage(PageId * pid) {

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -1,6 +1,3 @@
-#include <cmath>
-#include <iostream>
-#include <stringstream>
 #include "database.h"
 #include "heap_page.h"
 #include "no_such_element_exception.h"

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -66,10 +66,12 @@ void HeapPage::SetBeforeImage() {
 }
 
 int HeapPage::get_number_of_tuples() {
-  double pagesize = (double) Database::get_buffer_pool()->get_page_size() * 8;
-  double tuplesize = (double) (td->get_size() * 8 + 1);
-  double res = pagesize / tuplesize;
-  return (int) floor(res);
+  // bitwise shift left 3 bits to convert from bytes to bits
+  int page_size_in_bits = Database::get_buffer_pool()->PAGE_SIZE << 3;
+  int tuple_size_in_bits = table_schema.get_size() << 3;
+  int padding_bit = 1;
+
+  return page_size_in_bits / (tuple_size_in_bits + padding_bit);
 }
 
 int HeapPage::get_header_size() {

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -63,7 +63,7 @@ Page * HeapPage::GetBeforeImage() {
 void HeapPage::SetBeforeImage() {
 }
 
-int HeapPage::get_num_tuples() {
+int HeapPage::get_number_of_tuples() {
   double pagesize = (double) Database::get_buffer_pool()->get_page_size() * 8;
   double tuplesize = (double) (td->get_size() * 8 + 1);
   double res = pagesize / tuplesize;
@@ -71,12 +71,11 @@ int HeapPage::get_num_tuples() {
 }
 
 int HeapPage::get_header_size() {
-  double res = (double) numSlots / (double) 8;
-  return (int) ceil(res);
+  return (number_of_slots + 7) >> 3;
 }
 
-/*
-Tuple HeapPage::ReadNextTuple(byte[] data, int slotId) {
+Tuple * HeapPage::ReadInNextTuple(std::stringstream * byte_stream_pointer,
+                                  int slot_index) {
   if (!isSlotUsed(slotId)) {
     for (int i = 0; i < td.getSize(); i++) {
       try {
@@ -103,22 +102,24 @@ Tuple HeapPage::ReadNextTuple(byte[] data, int slotId) {
   return t;
 }
 
-void HeapPage::GetPageData(std::byte rep[]) {
+void HeapPage::CreatePageDataRepresentation(unsigned char * rep) {
 }
 
-void HeapPage::CreateEmptyPageData(std::byte rep[]) {
+  /* flush byte stream: necessary?
   int len = BufferPool.getPageSize();
   return new byte[len];
+void HeapPage::CreateEmptyPageDataRepresentation(unsigned char * rep) {
+void HeapPage::DeleteTuple(Tuple * t) {
 }
 */
 
-void HeapPage::DeleteTuple(Tuple t) {
+void HeapPage::InsertTuple(Tuple * t) {
 }
 
-void HeapPage::InsertTuple(Tuple t) {
+  for (int slot_index = 0; slot_index < number_of_slots; slot_index++) {
 }
 
-void HeapPage::AddTuple(Tuple t) {
+  throw DbException("This page is full.");
 }
 
 int HeapPage::GetNumEmptySlots() {
@@ -130,7 +131,7 @@ int HeapPage::GetNumEmptySlots() {
   return count;
 }
 
-bool HeapPage::IsSlotUsed(int i) {
+bool HeapPage::IsSlotUsed(int index) {
   int x = i / 8;
   int y = i % 8;
 
@@ -139,7 +140,7 @@ bool HeapPage::IsSlotUsed(int i) {
   */
 }
 
-void HeapPage::SetSlot(int i, bool value) {
+void HeapPage::SetSlot(int index, bool updated_status_of_slot) {
 }
 
 /* Not implemented
@@ -152,4 +153,7 @@ Iterator<tuple> HeapPage::iterator() {
   return arr.iterator();
 }
 */
+Field * HeapPage::ParseIntoField(Field::Type field_type,
+                                 std::stringstream * byte_stream_pointer) {
+}
 }

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -230,8 +230,8 @@ Iterator<tuple> HeapPage::iterator() {
   return arr.iterator();
 }
 */
-Field * HeapPage::ParseIntoField(Field::Type field_type,
-                                 std::stringstream * byte_stream_pointer) {
+
+// uses dynamic memory allocatiom: BEWARE
 // update documentation to reflect this
 // ensure that memory is released after use
 Tuple * HeapPage::ReadInNextTuple(std::stringstream * byte_stream_pointer,
@@ -270,5 +270,7 @@ Tuple * HeapPage::ReadInNextTuple(std::stringstream * byte_stream_pointer,
   return next_tuple;
 }
 
+Field * HeapPage::ParseIntoField(std::stringstream * byte_stream_pointer,
+                                 Field::Type field_type) {
 }
 }

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -192,6 +192,9 @@ void HeapPage::CreatePageDataRepresentation(unsigned char * rep) {
 }
 
 void HeapPage::CreateEmptyPageDataRepresentation(unsigned char * rep) {
+  rep = new unsigned char[BufferPool::PAGE_SIZE];
+}
+
 void HeapPage::DeleteTuple(Tuple * t) {
 }
 

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -137,12 +137,8 @@ int HeapPage::GetNumEmptySlots() {
 }
 
 bool HeapPage::IsSlotUsed(int index) {
-  int x = i / 8;
-  int y = i % 8;
-
-  /* Error here
-  return ((header[x] >> y) & 1) == 1;
-  */
+  // why?
+  return (header[index >> 3] & (1 << (index & 7))) != 0;
 }
 
 void HeapPage::SetSlot(int index, bool updated_status_of_slot) {

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -28,7 +28,7 @@ HeapPage::HeapPage(HeapPageId & pid, unsigned char data[])
 
   try {
     for (int i = 0; i < number_of_slots; i++) {
-      tuples.push_back(ReadInNextTuple(&byte_stream, i));
+      tuples.push_back(ParseNextTuple(&byte_stream, i));
     }
   } catch (NoSuchElementException e) {
     // print stack trace
@@ -234,7 +234,7 @@ Iterator<tuple> HeapPage::iterator() {
 // uses dynamic memory allocatiom: BEWARE
 // update documentation to reflect this
 // ensure that memory is released after use
-Tuple * HeapPage::ReadInNextTuple(std::stringstream * byte_stream_pointer,
+Tuple * HeapPage::ParseNextTuple(std::stringstream * byte_stream_pointer,
                                   int slot_index) {
   char input_char = 0;
   if (!IsSlotUsed(slot_index)) {
@@ -243,7 +243,7 @@ Tuple * HeapPage::ReadInNextTuple(std::stringstream * byte_stream_pointer,
         byte_stream_pointer->get(input_char);
       } catch (std::exception io_exception) {
         // change catch type
-        throw NoSuchElementException("Error reading empty tuple");
+        throw NoSuchElementException("Error parsing empty tuple.");
       }
     }
     return nullptr;
@@ -264,7 +264,7 @@ Tuple * HeapPage::ReadInNextTuple(std::stringstream * byte_stream_pointer,
     }
   } catch (std::exception e) {
     // change catch type
-    throw NoSuchElementException("Parsing error.");
+    throw NoSuchElementException("Error parsing tuple.");
   }
 
   return next_tuple;

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -61,6 +61,8 @@ Page * HeapPage::GetBeforeImage() {
 }
 
 void HeapPage::SetBeforeImage() {
+  delete[] old_data;
+  CreatePageDataRepresentation(old_data);
 }
 
 int HeapPage::get_number_of_tuples() {

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -37,6 +37,16 @@ HeapPage::HeapPage(HeapPageId & pid, unsigned char data[])
   SetBeforeImage();
 }
 
+HeapPage::~HeapPage() {
+  for (int slot_index = 0; slot_index < number_of_slots; slot_index++) {
+    delete tuples.at(slot_index);
+  }
+
+  delete[] header;
+  delete[] old_data;
+  delete id_of_transaction_that_dirtied_page;
+}
+
 const PageId & HeapPage::get_id() const {
   return pid;
 }

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -284,10 +284,4 @@ Tuple * HeapPage::ParseStreamForTuple(std::stringstream * byte_stream_pointer,
 
   return next_tuple;
 }
-
-Field * HeapPage::ParseIntoField(std::stringstream * byte_stream_pointer,
-                                 Field::Type field_type) {
-  // to be implemented
-  return nullptr;
-}
 }

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -3,6 +3,7 @@
 #include <stringstream>
 #include "database.h"
 #include "heap_page.h"
+#include "no_such_element_exception.h"
 
 namespace buzzdb {
 /**
@@ -49,19 +50,16 @@ void HeapPage::MarkDirty(bool dirty, TransactionId * tid) {
   id_of_transaction_that_dirtied_page = dirty ? tid : nullptr;
 }
 
+// uses dynamic memory allocatiom: BEWARE
+// update documentation to reflect this
+// ensure that memory is released after use
 Page * HeapPage::GetBeforeImage() {
   try {
-    /*
-    std::byte * old_data_ref = nullptr;
-    old_data_ref = old_data;
-    return new HeapPage(pid, old_data_ref);
-    */
-    return new HeapPage();
-  } catch (std::exception e) {
-    /*
-    System.exit(1);
-    */
+    return new HeapPage(pid, old_data);
+  } catch (std::exception io_exception) {
+    // implement properly
   }
+  return nullptr;
 }
 
 void HeapPage::SetBeforeImage() {

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -214,10 +214,24 @@ void HeapPage::DeleteTuple(Tuple * t) {
 }
 
 void HeapPage::InsertTuple(Tuple * t) {
-}
+  if (table_schema != t->get_tuple_desc()) {
+    throw DbException("Schema mismatch: Table and tuple");
+  }
+  if (t->get_record_id() != nullptr) {
+    if (pid == t->get_record_id()->get_page_id()) {
+      throw DbException("Tuple already resides on this page.");
+    }
+    throw DbException("Tuple already resides on another page.");
+  }
 
   for (int slot_index = 0; slot_index < number_of_slots; slot_index++) {
-}
+    if (!IsSlotUsed(slot_index)) {
+      tuples.at(slot_index) = t;
+      t->set_record_id(new RecordId(pid, slot_index));
+      SetSlot(slot_index, true);
+      return;
+    }
+  }
 
   throw DbException("This page is full.");
 }

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -42,6 +42,7 @@ const TransactionId * HeapPage::get_id_of_last_dirty_transaction() const {
 }
 
 void HeapPage::MarkDirty(bool dirty, TransactionId * tid) {
+  id_of_transaction_that_dirtied_page = dirty ? tid : nullptr;
 }
 
 Page * HeapPage::GetBeforeImage() {

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 #include "database.h"
 #include "heap_page.h"
+#include "db_exception.h"
 #include "no_such_element_exception.h"
 
 namespace buzzdb {
@@ -196,6 +197,20 @@ void HeapPage::CreateEmptyPageDataRepresentation(unsigned char * rep) {
 }
 
 void HeapPage::DeleteTuple(Tuple * t) {
+  if (pid == t->get_record_id()->get_page_id()) {
+    int tuple_number = t->get_record_id()->get_tuple_number();
+
+    if (tuple_number >= 0
+        && tuple_number < number_of_slots
+        && IsSlotUsed(tuple_number)) {
+      SetSlot(tuple_number, false);
+      // update tuple's record id
+      delete t->get_record_id();
+      t->set_record_id(nullptr);
+    }
+  }
+
+  throw DbException("Tuple not found on page");
 }
 
 void HeapPage::InsertTuple(Tuple * t) {

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -38,8 +38,7 @@ const PageId & HeapPage::get_id() const {
 }
 
 const TransactionId * HeapPage::get_id_of_last_dirty_transaction() const {
-  // some code goes here
-  // return null;
+  return id_of_transaction_that_dirtied_page;
 }
 
 void HeapPage::MarkDirty(bool dirty, TransactionId * tid) {

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -96,6 +96,7 @@ void HeapPage::CreatePageDataRepresentation(unsigned char * rep) {
   // might not be correct to read whole array into stream
   // how about the ending characters in an array?
   try {
+    // correctness needs to be checked
     byte_stream << *header;
   } catch (std::exception io_exception) {
     // change catch type
@@ -246,6 +247,8 @@ Iterator<tuple> HeapPage::iterator() {
 // ensure that memory is released after use
 Tuple * HeapPage::ParseNextTuple(std::stringstream * byte_stream_pointer,
                                   int slot_index) {
+  // if the slot is not set to be used, move internal stream pointer forward
+  // to next tuple, and return nullptr
   char input_char = 0;
   if (!IsSlotUsed(slot_index)) {
     for (int i = 0; i < table_schema.get_size(); i++) {
@@ -259,6 +262,7 @@ Tuple * HeapPage::ParseNextTuple(std::stringstream * byte_stream_pointer,
     return nullptr;
   }
 
+  // otherwise, parse the tuple.
   Tuple * next_tuple = new Tuple(table_schema);
   RecordId * rid = new RecordId(pid, slot_index);
   next_tuple->set_record_id(rid);

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -29,7 +29,7 @@ HeapPage::HeapPage(HeapPageId & pid, unsigned char data[])
 
   try {
     for (int i = 0; i < number_of_slots; i++) {
-      tuples.push_back(ParseNextTuple(&byte_stream, i));
+      tuples.push_back(ParseStreamForTuple(&byte_stream, i));
     }
   } catch (NoSuchElementException e) {
     // print stack trace
@@ -246,8 +246,8 @@ Iterator<tuple> HeapPage::iterator() {
 // uses dynamic memory allocatiom: BEWARE
 // update documentation to reflect this
 // ensure that memory is released after use
-Tuple * HeapPage::ParseNextTuple(std::stringstream * byte_stream_pointer,
-                                  int slot_index) {
+Tuple * HeapPage::ParseStreamForTuple(std::stringstream * byte_stream_pointer,
+                                      int slot_index) {
   // if the slot is not set to be used, move internal stream pointer forward
   // to next tuple, and return nullptr
   char input_char = 0;

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -13,9 +13,10 @@ HeapPage::HeapPage(HeapPageId & pid, unsigned char data[])
   : pid(pid),
     table_schema(Database::get_catalog()->get_tuple_desc(pid.get_table_id())),
     number_of_slots(get_number_of_tuples()),
-    header(new unsigned char[get_header_size()]),
     tuples(0),
-    old_data(nullptr) {
+    header(new unsigned char[get_header_size()]),
+    old_data(nullptr),
+    id_of_transaction_that_dirtied_page(nullptr) {
   std::stringstream byte_stream;
   byte_stream << data;
 
@@ -122,7 +123,7 @@ void HeapPage::CreatePageDataRepresentation(unsigned char * rep) {
     Tuple * tuple_at_slot_index = tuples.at(slot_index);
     for (int field_index = 0;
          field_index < table_schema.get_number_fields();
-         field_index) {
+         field_index++) {
       Field * field = tuple_at_slot_index->get_field(field_index);
       try {
         field->Serialize(&byte_stream);
@@ -210,8 +211,8 @@ void HeapPage::InsertTuple(Tuple * t) {
 
 int HeapPage::GetNumEmptySlots() {
   int count = 0;
-  for (int i = 0; i < sizeof(tuples) / sizeof(tuples[0]); ++i) {
-    if (!IsSlotUsed(i))
+  for (int slot_index = 0; slot_index < number_of_slots; slot_index++) {
+    if (!IsSlotUsed(slot_index))
       count++;
   }
   return count;
@@ -286,5 +287,7 @@ Tuple * HeapPage::ParseNextTuple(std::stringstream * byte_stream_pointer,
 
 Field * HeapPage::ParseIntoField(std::stringstream * byte_stream_pointer,
                                  Field::Type field_type) {
+  // to be implemented
+  return nullptr;
 }
 }

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -74,8 +74,8 @@ int HeapPage::get_header_size() {
   return (number_of_slots + 7) >> 3;
 }
 
-Tuple * HeapPage::ReadInNextTuple(std::stringstream * byte_stream_pointer,
-                                  int slot_index) {
+Tuple HeapPage::ReadInNextTuple(std::stringstream * byte_stream_pointer,
+                                int slot_index) {
   if (!isSlotUsed(slotId)) {
     for (int i = 0; i < td.getSize(); i++) {
       try {
@@ -111,7 +111,6 @@ void HeapPage::CreatePageDataRepresentation(unsigned char * rep) {
 void HeapPage::CreateEmptyPageDataRepresentation(unsigned char * rep) {
 void HeapPage::DeleteTuple(Tuple * t) {
 }
-*/
 
 void HeapPage::InsertTuple(Tuple * t) {
 }

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -42,7 +42,7 @@ const TransactionId * HeapPage::get_id_of_last_dirty_transaction() const {
   // return null;
 }
 
-void HeapPage::MarkDirty(bool dirty, TransactionId & tid) {
+void HeapPage::MarkDirty(bool dirty, TransactionId * tid) {
 }
 
 Page * HeapPage::GetBeforeImage() {

--- a/src/database/heap_page.cpp
+++ b/src/database/heap_page.cpp
@@ -142,6 +142,12 @@ bool HeapPage::IsSlotUsed(int index) {
 }
 
 void HeapPage::SetSlot(int index, bool updated_status_of_slot) {
+  // why?
+  if (updated_status_of_slot) {
+    header[index >> 3] |= (1 << (index & 7));
+  } else {
+    header[index >> 3] &= ~(1 << (index & 7));
+  }
 }
 
 /* Not implemented

--- a/src/database/integer_field.cpp
+++ b/src/database/integer_field.cpp
@@ -17,6 +17,10 @@ Field::Type IntegerField::get_type() const {
   return Type::INTEGER;
 }
 
+void IntegerField::Serialize(std::stringstream * byte_stream) {
+  // to be implemented
+}
+
 /*
 bool IntegerField::Compare(Predicate::OpType op_type, Field * operand) {
   IntegerField * operand_value_pointer = static_cast<IntegerField *>(operand);

--- a/src/database/integer_field.cpp
+++ b/src/database/integer_field.cpp
@@ -22,6 +22,10 @@ Field * IntegerField::ParseStreamForField(
   // to be implemented
 }
 
+void IntegerField::Serialize(std::stringstream * byte_stream_pointer) {
+  // to be implemented
+}
+
 /*
 bool IntegerField::Compare(Predicate::OpType op_type, Field * operand) {
   IntegerField * operand_value_pointer = static_cast<IntegerField *>(operand);

--- a/src/database/integer_field.cpp
+++ b/src/database/integer_field.cpp
@@ -17,7 +17,8 @@ Field::Type IntegerField::get_type() const {
   return Type::INTEGER;
 }
 
-void IntegerField::Serialize(std::stringstream * byte_stream) {
+Field * IntegerField::ParseStreamForField(
+    std::stringstream * byte_stream_pointer) {
   // to be implemented
 }
 

--- a/src/database/string_field.cpp
+++ b/src/database/string_field.cpp
@@ -22,6 +22,10 @@ Field * StringField::ParseStreamForField(
   // to be implemented
 }
 
+void StringField::Serialize(std::stringstream * byte_stream_pointer) {
+  // to be implemented
+}
+
 /*
 bool StringField::Compare(Predicate::OpType op_type, Field * operand) {
   StringField * operand_value_pointer = static_cast<StringField *>(operand);

--- a/src/database/string_field.cpp
+++ b/src/database/string_field.cpp
@@ -17,6 +17,10 @@ Field::Type StringField::get_type() const {
   return Type::STRING;
 }
 
+void StringField::Serialize(std::stringstream * byte_stream) {
+  // to be implemented
+}
+
 /*
 bool StringField::Compare(Predicate::OpType op_type, Field * operand) {
   StringField * operand_value_pointer = static_cast<StringField *>(operand);

--- a/src/database/string_field.cpp
+++ b/src/database/string_field.cpp
@@ -17,7 +17,8 @@ Field::Type StringField::get_type() const {
   return Type::STRING;
 }
 
-void StringField::Serialize(std::stringstream * byte_stream) {
+Field * StringField::ParseStreamForField(
+    std::stringstream * byte_stream_pointer) {
   // to be implemented
 }
 

--- a/src/include/buffer_pool.h
+++ b/src/include/buffer_pool.h
@@ -28,13 +28,16 @@ class BufferPool {
    */
   static const int DEFAULT_PAGES = 50;
 
+  /**
+    * Bytes per page, including header.
+    */
+  static const int PAGE_SIZE = 4096;
+
   std::vector<Page *> PageList;
 
   BufferPool(int num_pages, Catalog * catalog);
 
   ~BufferPool();
-
-  static int get_page_size();
 
   /**
    * Retrieve the specified page with the associated permissions.
@@ -136,10 +139,6 @@ class BufferPool {
   void FlushPages(TransactionId * tid);
 
  private:
-  /**
-    * Bytes per page, including header.
-    */
-  static const int PAGE_SIZE = 4096;
 
   std::vector<Page *> * buffer_pool;
 

--- a/src/include/field.h
+++ b/src/include/field.h
@@ -38,7 +38,7 @@ class Field {
   /**
    * Write the bytes representing the field to the specified Stream.
    */
-  virtual void Serialize(std::stringstream * byte_stream) = 0;
+  virtual void Serialize(std::stringstream * byte_stream_pointer) = 0;
 
   /**
    * Compares the value of the Field to the value of operand.

--- a/src/include/field.h
+++ b/src/include/field.h
@@ -5,6 +5,13 @@
 namespace buzzdb {
 /**
  * The Field abstract class is an interface for a field in a tuple.
+ * - Every class that implements this interface must implement the following
+ *   method:
+ *    static Field * ParseStreamForField(std::stringstream byte_stream_pointer)
+ * - The above constraint cannot be enforced by the specifications of this
+ *   interface as static methods cannot be virtual.
+ * - If this method is not implemented in a particular Field subclass, it will
+ *   not be possible to parse the particular field type from the byte stream.
  */
 class Field {
  public:

--- a/src/include/field.h
+++ b/src/include/field.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sstream>
+
 namespace buzzdb {
 /**
  * The Field abstract class is an interface for a field in a tuple.
@@ -29,9 +31,7 @@ class Field {
   /**
    * Write the bytes representing the field to the specified Stream.
    */
-  /*
-    virtual void serialize(DataOutputStream dos) = 0;
-  */
+  virtual void Serialize(std::stringstream * byte_stream) = 0;
 
   /**
    * Compares the value of the Field to the value of operand.

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -132,11 +132,11 @@ class HeapPage : public Page {
  private:
   HeapPageId pid;
   TupleDesc table_schema;
+  int number_of_slots;
   std::vector<Tuple *> tuples;
   unsigned char * header;
   unsigned char * old_data;
   TransactionId * id_of_transaction_that_dirtied_page;
-  int number_of_slots;
 
   /**
    * If the slot given by slot_index is set to be used, the next tuple is

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -65,8 +65,8 @@ class HeapPage : public Page {
    */
   int get_header_size();
 
-  Tuple ReadInNextTuple(std::stringstream * byte_stream_pointer,
-                        int slot_index);
+  Tuple * ReadInNextTuple(std::stringstream * byte_stream_pointer,
+                          int slot_index);
 
   void CreatePageDataRepresentation(unsigned char * rep);
 

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -92,13 +92,13 @@ class HeapPage : public Page {
   TransactionId * id_of_transaction_that_dirtied_page;
   int number_of_slots;
 
-  // byte oldDataLock = new byte(0);
-  int read_index;
+  /**
+   * Reads in a new tuple from the given byte stream.
    */
   Tuple * ReadInNextTuple(std::stringstream * byte_stream_pointer,
                           int slot_index);
 
-  Field * ParseIntoField(Field::Type field_type,
-                         std::stringstream * byte_stream_pointer);
+  Field * ParseIntoField(std::stringstream * byte_stream_pointer,
+                         Field::Type field_type);
 };
 }

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -149,8 +149,5 @@ class HeapPage : public Page {
    */
   Tuple * ParseStreamForTuple(std::stringstream * byte_stream_pointer,
                               int slot_index);
-
-  Field * ParseIntoField(std::stringstream * byte_stream_pointer,
-                         Field::Type field_type);
 };
 }

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -56,32 +56,29 @@ class HeapPage : public Page {
   /**
    * Returns the number of tuples in the heap page.
    */
-  int get_num_tuples();
+  int get_number_of_tuples();
 
   /**
    * Returns the size of the heap page's header.
    */
   int get_header_size();
 
-  /* Not implemented
-  Tuple ReadNextTuple(DataInputStream dis, int slotId)();
-  */
+  Tuple * ReadInNextTuple(std::stringstream * byte_stream_pointer,
+                          int slot_index);
 
-  // void GetPageData(std::byte rep[]);
+  void CreatePageDataRepresentation(unsigned char * rep);
 
-  // static void CreateEmptyPageData(std::byte rep[]);
+  static void CreateEmptyPageDataRepresentation(unsigned char * rep);
 
-  void DeleteTuple(Tuple t);
+  void DeleteTuple(Tuple * t);
 
-  void InsertTuple(Tuple t);
-
-  void AddTuple(Tuple t);
+  void InsertTuple(Tuple * t);
 
   int GetNumEmptySlots();
 
-  bool IsSlotUsed(int i);
+  bool IsSlotUsed(int index);
 
-  void SetSlot(int i, bool value);
+  void SetSlot(int index, bool updated_status_of_slot);
 
   /* Not implemented
   Iterator<tuple> iterator();
@@ -98,5 +95,8 @@ class HeapPage : public Page {
 
   // byte oldDataLock = new byte(0);
   int read_index;
+
+  Field * ParseIntoField(Field::Type field_type,
+                         std::stringstream * byte_stream_pointer);
 };
 }

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -20,7 +20,7 @@ class HeapPage : public Page {
   /**
    * Default constructor.
    */
-  HeapPage();
+  HeapPage() = delete;
 
   /**
    * Destructor

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -24,8 +24,8 @@ class HeapPage : public Page {
 
   /**
    * Constructor.
-  HeapPage(HeapPageId id, std::byte data[]);
    */
+  HeapPage(HeapPageId & id, unsigned char data[]);
 
   /**
    * Returns the id of the page.

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <iostream>
+#include <sstream>
 #include "heap_page_id.h"
 #include "page.h"
 #include "transaction_id.h"
@@ -63,8 +65,8 @@ class HeapPage : public Page {
    */
   int get_header_size();
 
-  Tuple * ReadInNextTuple(std::stringstream * byte_stream_pointer,
-                          int slot_index);
+  Tuple ReadInNextTuple(std::stringstream * byte_stream_pointer,
+                        int slot_index);
 
   void CreatePageDataRepresentation(unsigned char * rep);
 

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -39,7 +39,7 @@ class HeapPage : public Page {
   /**
    * Sets the dirty state of the page as dirtied by a particular transaction.
    */
-  void MarkDirty(bool dirty, TransactionId & tid) override;
+  void MarkDirty(bool dirty, TransactionId * tid) override;
 
   /**
    * Returns a representation of the Page before any modifications were made to

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -147,8 +147,8 @@ class HeapPage : public Page {
    * Throws:
    * - NoSuchElementException: If there is an error while parsing the tuple.
    */
-  Tuple * ParseNextTuple(std::stringstream * byte_stream_pointer,
-                          int slot_index);
+  Tuple * ParseStreamForTuple(std::stringstream * byte_stream_pointer,
+                              int slot_index);
 
   Field * ParseIntoField(std::stringstream * byte_stream_pointer,
                          Field::Type field_type);

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -23,6 +23,11 @@ class HeapPage : public Page {
   HeapPage();
 
   /**
+   * Destructor
+   */
+  ~HeapPage();
+
+  /**
    * Constructor.
    */
   HeapPage(HeapPageId & id, unsigned char data[]);

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -65,9 +65,6 @@ class HeapPage : public Page {
    */
   int get_header_size();
 
-  Tuple * ReadInNextTuple(std::stringstream * byte_stream_pointer,
-                          int slot_index);
-
   void CreatePageDataRepresentation(unsigned char * rep);
 
   static void CreateEmptyPageDataRepresentation(unsigned char * rep);
@@ -97,6 +94,9 @@ class HeapPage : public Page {
 
   // byte oldDataLock = new byte(0);
   int read_index;
+   */
+  Tuple * ReadInNextTuple(std::stringstream * byte_stream_pointer,
+                          int slot_index);
 
   Field * ParseIntoField(Field::Type field_type,
                          std::stringstream * byte_stream_pointer);

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -89,11 +89,12 @@ class HeapPage : public Page {
 
  private:
   HeapPageId pid;
-  TupleDesc * td;
-  // std::byte * header;
-  Tuple * tuples;
-  int numSlots;
-  // std::byte * old_data;
+  TupleDesc table_schema;
+  std::vector<Tuple *> tuples;
+  unsigned char * header;
+  unsigned char * old_data;
+  TransactionId * id_of_transaction_that_dirtied_page;
+  int number_of_slots;
 
   // byte oldDataLock = new byte(0);
   int read_index;

--- a/src/include/heap_page.h
+++ b/src/include/heap_page.h
@@ -95,7 +95,7 @@ class HeapPage : public Page {
   /**
    * Reads in a new tuple from the given byte stream.
    */
-  Tuple * ReadInNextTuple(std::stringstream * byte_stream_pointer,
+  Tuple * ParseNextTuple(std::stringstream * byte_stream_pointer,
                           int slot_index);
 
   Field * ParseIntoField(std::stringstream * byte_stream_pointer,

--- a/src/include/integer_field.h
+++ b/src/include/integer_field.h
@@ -42,7 +42,7 @@ class IntegerField : public Field {
   /**
    * Write the bytes representing the IntegerField to the specified Stream.
    */
-  void Serialize(std::stringstream * byte_stream) override;
+  void Serialize(std::stringstream * byte_stream_pointer) override;
 
   /**
    * Compares the value of the IntegerField to the value of operand.

--- a/src/include/integer_field.h
+++ b/src/include/integer_field.h
@@ -35,6 +35,11 @@ class IntegerField : public Field {
   Type get_type() const override;
 
   /**
+   * Creates an IntegerField by parsing the stream and returns a pointer to it.
+   */
+  static Field * ParseStreamForField(std::stringstream * byte_stream_pointer);
+
+  /**
    * Write the bytes representing the IntegerField to the specified Stream.
    */
   void Serialize(std::stringstream * byte_stream) override;

--- a/src/include/integer_field.h
+++ b/src/include/integer_field.h
@@ -37,9 +37,7 @@ class IntegerField : public Field {
   /**
    * Write the bytes representing the IntegerField to the specified Stream.
    */
-  /* To be implemented
-    void serialize(DataOutputStream dos) override;
-  */
+  void Serialize(std::stringstream * byte_stream) override;
 
   /**
    * Compares the value of the IntegerField to the value of operand.

--- a/src/include/page.h
+++ b/src/include/page.h
@@ -35,7 +35,7 @@ class Page {
   /**
    * Sets the dirty state of the page as dirtied by a particular transaction.
    */
-  virtual void MarkDirty(bool dirty, TransactionId & tid) = 0;
+  virtual void MarkDirty(bool dirty, TransactionId * tid) = 0;
  
   /* Need to use another input parameter type besides byte
   virtual void GetPageData(std::byte content_rep[]) = 0;

--- a/src/include/page.h
+++ b/src/include/page.h
@@ -6,11 +6,12 @@
 namespace buzzdb {
 /**
  * The Page interface class is an interface for page representations.
+ * - This interface is largely utilized by the BufferPool.
  * - A page contains tuples, which contain fields.
- * - A page is contained in a table, which is typically implemented as a DbFile.
- * 
- * Pages may be "dirty", meaning that they have been modified since they
- * were last written out to disk.
+ * - A page is contained in a table, which is typically implemented as a
+ *   DbFile.
+ * - A page may be "dirty", meaning that it has been modified since it was last
+ *   written out to disk.
  */
 class Page {
  public:

--- a/src/include/string_field.h
+++ b/src/include/string_field.h
@@ -36,6 +36,11 @@ class StringField : public Field {
   Type get_type() const override;
 
   /**
+   * Creates an StringField by parsing the stream and returns a pointer to it.
+   */
+  static Field * ParseStreamForField(std::stringstream * byte_stream_pointer);
+
+  /**
    * Write the bytes representing the StringField to the specified Stream.
    */
   void Serialize(std::stringstream * byte_stream) override;

--- a/src/include/string_field.h
+++ b/src/include/string_field.h
@@ -38,9 +38,7 @@ class StringField : public Field {
   /**
    * Write the bytes representing the StringField to the specified Stream.
    */
-  /* To be implemented
-    void serialize(DataOutputStream dos) override;
-  */
+  void Serialize(std::stringstream * byte_stream) override;
 
   /**
    * Compares the value of the StringField to the value of operand.

--- a/src/include/string_field.h
+++ b/src/include/string_field.h
@@ -43,7 +43,7 @@ class StringField : public Field {
   /**
    * Write the bytes representing the StringField to the specified Stream.
    */
-  void Serialize(std::stringstream * byte_stream) override;
+  void Serialize(std::stringstream * byte_stream_pointer) override;
 
   /**
    * Compares the value of the StringField to the value of operand.


### PR DESCRIPTION
Partially addresses #18.

The following methods remain non-functional:
- `HeapPage::Iterator`
- `Field::Serialize`
- `Field::ParseStreamForField`

---

**Not** ready for review yet.